### PR TITLE
Rename Lurker to Kikimora

### DIFF
--- a/gamedata/configs/text/rus/ui_st_ap_news.xml
+++ b/gamedata/configs/text/rus/ui_st_ap_news.xml
@@ -40,7 +40,7 @@
     <string id="st_ap_news_species_rat"><text>Крысы</text></string>
     <string id="st_ap_news_species_karlik"><text>Карлики</text></string>
     <string id="st_ap_news_species_psysucker"><text>Псисосы</text></string>
-    <string id="st_ap_news_species_lurker"><text>Лурки</text></string>
+    <string id="st_ap_news_species_lurker"><text>Кикиморы</text></string>
 
     <!-- ========================================================================= -->
     <!-- PER-CONSEQUENCE TEMPLATES                                                  -->


### PR DESCRIPTION
I have updated the name of the monster previously labeled as "Lurker" (Люркер).

Changes:
- Renamed "Лурки" to "Кикиморы" (Kikimors).

Reasoning:
The creature originates from Slavic mythology and was add to the stalker anomaly from the Metro 2033 franchise, where it is officially called "Kikimora". "Lurker" is merely an English adaptation of that name. Translating it back to Russian as "Люркер" is a mistranslation that breaks the original lore. Restoring "Kikimora" is more accurate.