### PR TITLE
fix(news): fix incoherent english in news message templates

### DIFF
--- a/gamedata/configs/text/eng/ui_st_ap_news.xml
+++ b/gamedata/configs/text/eng/ui_st_ap_news.xml
@@ -66,7 +66,7 @@
     <string id="st_ap_news_tpl_massacre_scavenge_002"><text>Saw #subject_species# feeding on the #other_faction# dead at #location# before any recovery crew came up.</text></string>
     <string id="st_ap_news_tpl_massacre_scavenge_003"><text>I was downwind of #location# #ago# when a #subject_species# pack moved in on the #other_faction# bodies. Nothing was left to identify.</text></string>
     <string id="st_ap_news_tpl_massacre_scavenge_004"><text>Tracks at #location# show a #subject_species# pack came onto the #other_faction# kill before anyone could retrieve.</text></string>
-    <string id="st_ap_news_tpl_massacre_scavenge_005"><text>A #subject_species# pack fed on the #other_faction# dead at #location# until the bones were picked clean.</text></string>
+    <string id="st_ap_news_tpl_massacre_scavenge_005"><text>A #subject_species# pack fed on the #other_faction# dead at #location# #ago# until the bones were picked clean.</text></string>
 
     <!-- squadkill_revenge (TWO-PARTY: subject = avenger, other = killer) -->
     <string id="st_ap_news_tpl_squadkill_revenge_001"><text>Heard a #subject_faction# crew left #location# #ago# hunting #other_faction# after a sister squad got cut down.</text></string>
@@ -87,7 +87,7 @@
     <string id="st_ap_news_tpl_basekill_support_002"><text>Saw a #subject_faction# crew burning fuel toward #location# #ago# to back up the guys holding against #other_faction# at the gate.</text></string>
     <string id="st_ap_news_tpl_basekill_support_003"><text>I was with the #subject_faction# crew that came up to back up #location# #ago#. We hit #other_faction# at the gate but the wall was already down.</text></string>
     <string id="st_ap_news_tpl_basekill_support_004"><text>Tracks at #location# show #subject_faction# brought another crew up to retake the gate from #other_faction# after the wall fell.</text></string>
-    <string id="st_ap_news_tpl_basekill_support_005"><text>#subject_name# led #subject_faction# backup at #other_faction# at #location# #ago# but the wall came down anyway.</text></string>
+    <string id="st_ap_news_tpl_basekill_support_005"><text>#subject_name# led #subject_faction# backup against #other_faction# at #location# #ago# but the wall came down anyway.</text></string>
 
     <!-- basekill_flee (TWO-PARTY: subject = defender, other = attacker took base) -->
     <string id="st_ap_news_tpl_basekill_flee_001"><text>Heard #subject_faction# pulled out of #location# #ago#. #other_faction# hold the gate now.</text></string>
@@ -101,7 +101,7 @@
     <string id="st_ap_news_tpl_alpha_promote_002"><text>Saw a new #subject_species# bull take the pack at #location# #ago#. Bigger than the one before.</text></string>
     <string id="st_ap_news_tpl_alpha_promote_003"><text>I was on the ridge over #location# #ago# when the #subject_species# pack changed leaders. The new alpha ran two stalkers off before noon.</text></string>
     <string id="st_ap_news_tpl_alpha_promote_004"><text>Tracks at #location# show the #subject_species# pack changed leaders #ago#. The new alpha is heavier than the last.</text></string>
-    <string id="st_ap_news_tpl_alpha_promote_005"><text>A new #subject_species# alpha leads the pack at #location# #ago#.</text></string>
+    <string id="st_ap_news_tpl_alpha_promote_005"><text>A new #subject_species# alpha seized the pack at #location# #ago#.</text></string>
 
     <!-- alphakill_targeted (TWO-PARTY mutant: subject = pack, other = killer human) -->
     <string id="st_ap_news_tpl_alphakill_targeted_001"><text>Heard the #subject_species# alpha at #location# went down to #other_faction# fire #ago#.</text></string>
@@ -226,7 +226,7 @@
     <string id="st_ap_news_tpl_supply_trader_001"><text>Heard #subject_faction# crowded the trader at #location# #ago#.</text></string>
     <string id="st_ap_news_tpl_supply_trader_002"><text>Saw #subject_faction# dump packs on the trader counter at #location# #ago# until the till ran low.</text></string>
     <string id="st_ap_news_tpl_supply_trader_003"><text>I was in line at the trader at #location# #ago# when #subject_faction# came in. They paid out gear for an hour. I waited longer.</text></string>
-    <string id="st_ap_news_tpl_supply_trader_004"><text>Tracks to #location# #ago# show #subject_faction# came in heavy and walked out lighter and richer.</text></string>
+    <string id="st_ap_news_tpl_supply_trader_004"><text>Tracks at #location# show #subject_faction# came in heavy and walked out lighter and richer #ago#.</text></string>
     <string id="st_ap_news_tpl_supply_trader_005"><text>#subject_name# took a #subject_faction# crew to the trader at #location# #ago#.</text></string>
 
     <!-- job_outpost (SINGLE STALKER need: post/wire) -->
@@ -276,21 +276,21 @@
     <string id="st_ap_news_tpl_instincts_sleep_002"><text>Saw a #subject_species# pack file back into the den at #location# #ago# at first light.</text></string>
     <string id="st_ap_news_tpl_instincts_sleep_003"><text>I crossed past #location# at first light #ago# and the #subject_species# pack had filed back into the den off-cycle till dusk.</text></string>
     <string id="st_ap_news_tpl_instincts_sleep_004"><text>Tracks at #location# show a #subject_species# pack went down in the den and has not stirred.</text></string>
-    <string id="st_ap_news_tpl_instincts_sleep_005"><text>A #subject_species# pack is asleep in the #location# den #ago#.</text></string>
+    <string id="st_ap_news_tpl_instincts_sleep_005"><text>A #subject_species# pack went to sleep in the #location# den #ago#.</text></string>
 
     <!-- instincts_explore (SINGLE MUTANT instinct) -->
     <string id="st_ap_news_tpl_instincts_explore_001"><text>Heard #subject_species# cut a long line across #location# #ago# with no heading.</text></string>
     <string id="st_ap_news_tpl_instincts_explore_002"><text>Saw a #subject_species# pack moving past #location# #ago# spread thin and not following a trail.</text></string>
     <string id="st_ap_news_tpl_instincts_explore_003"><text>I was on my way back when I crossed #subject_species# sign near #location# #ago#. The pack had cut a long line through with no pattern anyone could read.</text></string>
     <string id="st_ap_news_tpl_instincts_explore_004"><text>Fresh #subject_species# tracks at #location# #ago# go in a long line nobody can read for heading or pack sign.</text></string>
-    <string id="st_ap_news_tpl_instincts_explore_005"><text>A #subject_species# pack is roaming across #location# #ago#.</text></string>
+    <string id="st_ap_news_tpl_instincts_explore_005"><text>A #subject_species# pack was seen roaming through #location# #ago#.</text></string>
 
     <!-- instincts_socialize (SINGLE MUTANT instinct) -->
     <string id="st_ap_news_tpl_instincts_socialize_001"><text>Heard #subject_species# gathered at #location# #ago# in numbers that do not happen by accident.</text></string>
     <string id="st_ap_news_tpl_instincts_socialize_002"><text>Saw a #subject_species# pack converging at #location# #ago# from every direction at once.</text></string>
     <string id="st_ap_news_tpl_instincts_socialize_003"><text>I was on the high ground when the calls started carrying off #location# #ago#. #subject_species# pulled together into a pack bigger than usual.</text></string>
     <string id="st_ap_news_tpl_instincts_socialize_004"><text>Tracks at #location# #ago# show a #subject_species# pack converged from three directions and stayed together after.</text></string>
-    <string id="st_ap_news_tpl_instincts_socialize_005"><text>A #subject_species# pack is gathering at #location# #ago#.</text></string>
+    <string id="st_ap_news_tpl_instincts_socialize_005"><text>A #subject_species# pack gathered at #location# #ago#.</text></string>
 
     <!-- instincts_scatter (SINGLE MUTANT instinct) -->
     <string id="st_ap_news_tpl_instincts_scatter_001"><text>Heard #subject_species# bolted from #location# #ago# without stopping, and whatever spooked them is still there.</text></string>


### PR DESCRIPTION
7 fixes to `gamedata/configs/text/eng/ui_st_ap_news.xml` where messages read as unnatural PDA text or were grammatically broken.

| String ID | Problem | Fix |
|-----------|---------|-----|
| `basekill_support_005` | Double "at" preposition | "at #other_faction#" → "against #other_faction#" |
| `alpha_promote_005` | Present tense "leads" + #ago# | → "seized the pack" |
| `massacre_scavenge_005` | Missing #ago# time anchor | Added before "until" |
| `supply_trader_004` | "Tracks to" + mid-sentence #ago# | → "Tracks at" with #ago# at end |
| `instincts_sleep_005` | Present "is asleep" + #ago# | → "went to sleep" |
| `instincts_explore_005` | Present "is roaming" + #ago# | → "was seen roaming through" |
| `instincts_socialize_005` | Present "is gathering" + #ago# | → "gathered" |
