### PR TITLE
fix(massacre): accumulate the death cluster before the publish-budget gate

### DIFF
--- a/gamedata/scripts/ap_ext_cause_massacre.script
+++ b/gamedata/scripts/ap_ext_cause_massacre.script
@@ -19,9 +19,6 @@ local _alignment_human = ap_ext_const.alignment_human
 
 local function _on_squad_npc_death(trace, squad, se_victim, se_killer)
     if not cfg.cause_massacre_enabled then return { code = RESULT.FAILED_RULES, reason = REASON.DISABLED } end
-    if not ap_core_limiter.check_cause_rate_limit(CATEGORY, cfg[CAP_KEY]) then
-        return { code = RESULT.FAILED_RULES, reason = REASON.BUDGET_EXHAUSTED }
-    end
     if not se_victim then return { code = RESULT.FAILED_RULES, reason = REASON.NO_VICTIM } end
     if not _alignment_human[squad.player_id] then return { code = RESULT.FAILED_RULES, reason = REASON.WRONG_ALIGNMENT } end
     local killer_squad = se_killer and xsquad.get_squad_by_member(se_killer.id) or nil
@@ -36,6 +33,14 @@ local function _on_squad_npc_death(trace, squad, se_victim, se_killer)
 
     local count = ap_core_util.count_until_threshold(_deaths, smart.id, cfg.cause_massacre_threshold)
     if not count then return { code = RESULT.FAILED_RULES, reason = REASON.BELOW_THRESHOLD } end
+
+    -- Gate publication, not accumulation. count_until_threshold above advances the death cluster
+    -- regardless of budget, so massacre keeps building during the sustained combat that produces
+    -- it. Previously this check sat at the top, so an exhausted (shared) REACTIONS budget dropped
+    -- the death before it was ever counted, starving the cluster exactly when it should grow.
+    if not ap_core_limiter.check_cause_rate_limit(CATEGORY, cfg[CAP_KEY]) then
+        return { code = RESULT.FAILED_RULES, reason = REASON.BUDGET_EXHAUSTED }
+    end
 
     ap_core_limiter.increment_cause_counter(CATEGORY)
     return {


### PR DESCRIPTION
## Problem
`_on_squad_npc_death` ran `check_cause_rate_limit` (a peek on the shared REACTIONS budget) at the
**top**, before `count_until_threshold` accumulates the per-smart death cluster. The REACTIONS
budget is shared across massacre/squadkill/basekill/alpha/alphakill/harvest/wounded, so during a
firefight other reactive causes exhaust it — and every massacre-eligible death then returns
`BUDGET_EXHAUSTED` *before* being counted. The cluster never grows, so massacre fails to fire in
exactly the scenario it exists for.

## Fix
Move the budget peek to **after** `count_until_threshold`. The death is always tallied into the
cluster; only the actual publish is rate-limited. Budget consumption (`increment_cause_counter`)
was already at the end, so this only relocates the peek.

## Repro
1. MCM → DEBUG. Drive REACTIONS budget to exhaustion (heavy multi-faction combat, or lower
   `cause_max_reactions`).
2. Stage a cluster of deaths near a non-base smart.
3. **Before:** deaths log `BUDGET_EXHAUSTED`, cluster count never advances, no `cause:massacre`.
   **After:** cluster advances per death; `cause:massacre` fires once budget frees.