### PR TITLE
fix(stash): spend the scan-budget slot only on a successful scan

### DIFF
--- a/gamedata/scripts/ap_ext_causes_stash.script
+++ b/gamedata/scripts/ap_ext_causes_stash.script
@@ -96,11 +96,15 @@ local function _try_picked_cause(trace, squad, level_id, opts)
         if opts.budget.remaining <= 0 then
             return { code = RESULT.FAILED_RULES, reason = REASON.BUDGET_EXHAUSTED }
         end
-        opts.budget.remaining = opts.budget.remaining - 1
         local dst = ap_core_util.find_smart_observed(trace, opts.stash.position, {
             level_id = level_id, filter = function(s) return not xsmart.is_base(s) end,
         })
         if not dst then return { code = RESULT.FAILED_SCAN, reason = REASON.NO_SMART } end
+        -- Consume the scan slot only on a successful scan. A missed ambush scan must not spend the
+        -- budget, else the loot fallback (the [STASH_AMBUSH, STASH_LOOT] cascade for outlaws) hits
+        -- BUDGET_EXHAUSTED and never scans -- defeating "ambush preferred, loot as fallback".
+        -- Worst case is 2 find_smart calls per _on_smart (ambush miss + loot), within the perf budget.
+        opts.budget.remaining = opts.budget.remaining - 1
         local t_ok, t_last, t_targ, t_score = ap_ext_util.is_tactically_eligible(squad, dst)
         if not t_ok then
             return { code = RESULT.FAILED_RULES, reason = REASON.LOW_TACTICS, last_of_faction = t_last, smart_targeted = t_targ, score = t_score }


### PR DESCRIPTION
## Problem
For an outlaw at a non-empty stash, `_pick_branches` returns `[STASH_AMBUSH, STASH_LOOT]` and the
caller cascades them, "ambush preferred, loot as fallback". But `_try_picked_cause` decremented the
shared 1-slot scan budget **before** the `find_smart_observed` call. If ambush passes RULES
(threshold + personality) but its scan returns nil (`FAILED_SCAN` — no non-base smart near the
stash), the budget is already 0, so the loot branch hits `BUDGET_EXHAUSTED` and **never scans**.
The documented fallback is defeated exactly when ambush can't find a destination.

## Fix
Move the budget decrement to **after** a successful scan (`dst` found). A failed scan no longer
spends the slot, so the loot fallback still gets to scan. Worst case is 2 `find_smart` calls per
`_on_smart` (ambush miss + loot), well within the per-call perf budget.

## Repro
1. MCM → DEBUG. Outlaw squad near a non-empty stash with no non-base smart in EYE range.
2. **Before:** ambush logs `FAILED_SCAN`, loot logs `BUDGET_EXHAUSTED`, nothing fires.
   **After:** ambush `FAILED_SCAN`, loot scans and can fire.