### PR TITLE
fix(smart_mutator): enforce per-level cap when restoring mutations on load

### DIFF
--- a/gamedata/scripts/ap_ext_smart_mutator.script
+++ b/gamedata/scripts/ap_ext_smart_mutator.script
@@ -292,16 +292,21 @@ local function _restore_conquered(now)
         ap_core_debug.info("[MUTATOR.SMART] on_game_load: conquest disabled, skipped restore")
         return
     end
-    local restored = 0
+    local restored, skipped = 0, 0
     for smart_id, data in pairs(_conquered_pending) do
         if type(data) ~= "table" then goto continue end
         if not data.faction or not data.level_id then goto continue end
+        -- Enforce the per-level cap on restore too. The cap can be lowered in MCM between sessions
+        -- (e.g. switching presets Chaotic -> Calm); without this, every saved conquest is reinstated
+        -- and the new cap is permanently exceeded (the scan loop never re-checks it).
+        -- can_conquest_on_level counts the entries already restored in this pass.
+        if not can_conquest_on_level(data.level_id) then skipped = skipped + 1; goto continue end
         _conquered_smarts[smart_id] = { faction = data.faction, level_id = data.level_id, conquered_at = data.conquered_at or now }
         restored = restored + 1
         ::continue::
     end
     _conquered_pending = nil
-    ap_core_debug.debug("[MUTATOR.SMART] on_game_load: conquest restored=%d", restored)
+    ap_core_debug.debug("[MUTATOR.SMART] on_game_load: conquest restored=%d skipped=%d", restored, skipped)
 end
 
 local function _restore_swarmed(now)
@@ -311,16 +316,19 @@ local function _restore_swarmed(now)
         ap_core_debug.info("[MUTATOR.SMART] on_game_load: swarm disabled, skipped restore")
         return
     end
-    local restored = 0
+    local restored, skipped = 0, 0
     for smart_id, data in pairs(_swarmed_pending) do
         if type(data) ~= "table" then goto continue end
         if not data.faction or not data.level_id then goto continue end
+        -- Enforce the per-level cap on restore (cap can be lowered in MCM between sessions).
+        -- can_swarm_on_level counts the entries already restored in this pass.
+        if not can_swarm_on_level(data.level_id) then skipped = skipped + 1; goto continue end
         _swarmed_smarts[smart_id] = { faction = data.faction, level_id = data.level_id, swarmed_at = data.swarmed_at or now }
         restored = restored + 1
         ::continue::
     end
     _swarmed_pending = nil
-    ap_core_debug.debug("[MUTATOR.SMART] on_game_load: swarm restored=%d", restored)
+    ap_core_debug.debug("[MUTATOR.SMART] on_game_load: swarm restored=%d skipped=%d", restored, skipped)
 end
 
 local function _restore_infested(now)
@@ -330,16 +338,19 @@ local function _restore_infested(now)
         ap_core_debug.info("[MUTATOR.SMART] on_game_load: infest disabled, skipped restore")
         return
     end
-    local restored = 0
+    local restored, skipped = 0, 0
     for smart_id, data in pairs(_infested_pending) do
         if type(data) ~= "table" then goto continue end
         if not data.faction or not data.level_id then goto continue end
+        -- Enforce the per-level cap on restore (cap can be lowered in MCM between sessions).
+        -- can_infest_on_level counts the entries already restored in this pass.
+        if not can_infest_on_level(data.level_id) then skipped = skipped + 1; goto continue end
         _infested_smarts[smart_id] = { faction = data.faction, level_id = data.level_id, infested_at = data.infested_at or now }
         restored = restored + 1
         ::continue::
     end
     _infested_pending = nil
-    ap_core_debug.debug("[MUTATOR.SMART] on_game_load: infest restored=%d", restored)
+    ap_core_debug.debug("[MUTATOR.SMART] on_game_load: infest restored=%d skipped=%d", restored, skipped)
 end
 
 local function _on_game_load()


### PR DESCRIPTION
## Problem
`conquer_smart`/`swarm_smart`/`infest_smart` honor the per-level caps
(`can_conquest_on_level`/`can_swarm_on_level`/`can_infest_on_level`), but the restore path
(`_restore_conquered`/`_restore_swarmed`/`_restore_infested`, run at `on_game_load`) reinstates
**every** saved entry with no cap check. If a cap is lowered in MCM between sessions (e.g. switching
presets Chaotic → Calm), all previously-saved mutations are restored and the new cap is exceeded
**permanently** — the 60s scan loop only handles decay/respawn, never re-checks the cap. The engine
has no cross-smart/per-level cap of its own (only per-smart `max_population`), so nothing else
catches the over-spread.

## Fix
Call the matching `can_*_on_level(data.level_id)` before reinstating each entry. The cap function
counts entries already restored this pass, so the restore self-limits to the current cap; excess
entries are skipped (and logged as `skipped=N`). A skipped smart simply reverts to its vanilla
spawns (the engine rebuilds `respawn_params` from LTX on load anyway).

## Repro
1. Conquer/swarm/infest several smarts on one level. Save.
2. Lower the per-level cap in MCM (or apply the Calm preset). Reload.
3. **Before:** all prior mutations restored, level over-cap forever.
   **After:** restore trims to the cap; `restored=N skipped=M` in the log.