### PR TITLE
fix(chase): validate the chase target is a live squad on each re-target

### DIFF
--- a/gamedata/scripts/ap_ext_common.script
+++ b/gamedata/scripts/ap_ext_common.script
@@ -1,7 +1,7 @@
 --- ap_ext_common: Shared ext-domain dispatch patterns. Today: chase pattern (recursive on_arrive).
 
 local ipairs, pairs = ipairs, pairs
-local xobject, xsmart, xlevel = xobject, xsmart, xlevel
+local xobject, xsmart, xlevel, xsquad = xobject, xsmart, xlevel, xsquad
 local ap_core_debug, ap_core_broker, ap_core_util = ap_core_debug, ap_core_broker, ap_core_util
 
 local RESULT = ap_core_const.RESULT
@@ -63,6 +63,11 @@ function make_on_arrive(opts)
         end
         local target_squad = xobject.se(target_squad_id)
         if not target_squad then return end
+        -- Guard against a recycled/dead target id. The server id may resolve to a different object
+        -- (reused slot) or to an emptied squad after the target was wiped between arrival ticks.
+        -- The initial find_squads path validates this (xsquad._squad_base_valid); the recursive
+        -- re-target did not -- end the chase instead of pursuing a stranger or a corpse-less husk.
+        if not xsquad.is_squad(target_squad) or target_squad:npc_count() == 0 then return end
         local level_id = xlevel.get_level_id(target_squad)
         if not level_id then return end
         if xlevel.get_level_id(squad) ~= level_id then return end


### PR DESCRIPTION
## Problem
`make_on_arrive`'s recursive closure (revenge / rob / alphakill-targeted chases) re-resolves the
target via `xobject.se(target_squad_id)` on each arrival and checks only non-nil + same-level. It
never verifies the resolved object is still a squad with living members. If the target was wiped
between two arrival ticks, the server id may be recycled to a different object, or resolve to an
emptied squad — and the chasers get re-routed toward that object's position via
`find_smart(target_squad.position, ...)`. The *initial* `find_squads` path already rejects this
(`xsquad._squad_base_valid` drops `npc_count()==0`); only the recursion lacked the guard.

## Fix
After resolving `target_squad`, bail when it isn't a squad (`xsquad.is_squad`) or has no members
(`npc_count() == 0`) — ending the chase, matching the initial-dispatch validation. Adds `xsquad`
to the module requires.

## Repro
1. MCM → DEBUG. Trigger a chase (e.g. squadkill revenge) against a non-player squad.
2. Wipe the target squad mid-pursuit.
3. **Before:** chasers may re-route to a reused id's location / a corpse-less husk until
   `max_chases`. **After:** chase ends cleanly on the next arrival tick.