### PR TITLE
fix(broker): refresh off-map home level on re-dispatch

### DIFF
--- a/gamedata/scripts/ap_core_broker.script
+++ b/gamedata/scripts/ap_core_broker.script
@@ -448,11 +448,19 @@ end
 -- @cost O(1) | 1 luabind (xlevel.get_level_id) on first offmap capture, 0 thereafter
 local function _capture_home_level(squad, opts)
     if not opts.offmap then return true end
-    if _ap_squad_home_level[squad.id] then return true end
+    -- Keep the captured home stable during an active off-map session, but refresh it on a fresh
+    -- dispatch when no session is active. The home_level entry is only cleared on entity unregister
+    -- or the load-sweep, never on normal session completion, so a live squad that finished a round
+    -- trip, moved to another level, and is re-dispatched off-map would otherwise inherit its first
+    -- home and route the return leg to the wrong (stale) level.
+    if _ap_squad_home_level[squad.id] and is_offmap_dispatched(squad.id) then return true end
     local lid = xlevel.get_level_id(squad)
-    if not lid then return false end
-    _ap_squad_home_level[squad.id] = lid
-    return true
+    if lid then
+        _ap_squad_home_level[squad.id] = lid
+        return true
+    end
+    -- Level momentarily unavailable (mid-transition): keep any prior value, else refuse.
+    return _ap_squad_home_level[squad.id] ~= nil
 end
 
 -- Merge per-call session state into the new scripted_squad data entry. Off-map dispatches


### PR DESCRIPTION
## Problem
`_ap_squad_home_level[id]` is captured once on a squad's first off-map dispatch and only cleared on
`SERVER_ENTITY_ON_UNREGISTER` or the load-sweep — **not** when an off-map session completes
normally (home arrival just drops the `_ap_scripted_squads` entry). `_capture_home_level`
early-returned whenever the entry was already set. So a still-alive squad that finished a round
trip, then relocated to another level by ordinary A-Life, then got re-dispatched off-map, inherited
its **first** home level. `_init_offmap_session` copies that stale value and the return leg routes
to the wrong level. (It still returns to a valid level, so no stuck/leak — just the wrong home.)

## Fix
Refresh `_ap_squad_home_level[id]` on a fresh off-map dispatch when no session is active
(`is_offmap_dispatched(id)` is false); keep it stable during an active session. Falls back to the
prior value if the current level is momentarily unavailable mid-transition.

## Repro
1. MCM → DEBUG. Off-map dispatch squad S from level A; let it round-trip home to A.
2. Let S relocate to level B (vanilla A-Life), then trigger another off-map dispatch from B.
3. **Before:** `[SQUAD.OFFMAP] register: home_level=<A>` (stale) → returns to A.
   **After:** `home_level=<B>` → returns to B.